### PR TITLE
Fix security checks

### DIFF
--- a/ai-excel-editor.php
+++ b/ai-excel-editor.php
@@ -606,20 +606,18 @@ class AI_Excel_Editor {
             $valid = wp_verify_nonce($nonce, 'ai_excel_editor_nonce');
             if (!$valid) {
                 aisheets_debug('Nonce verification failed. Provided: ' . $nonce);
-                aisheets_debug('This could be due to nonce timeout or mismatch. Continuing anyway for testing.');
-                // For testing, comment out the following error response
-                // wp_send_json_error(array(
-                //     'message' => 'Security check failed',
-                //     'code' => 'nonce_failure',
-                //     'details' => 'The security token has expired or is invalid'
-                // ));
-                // return;
+                aisheets_debug('This could be due to nonce timeout or mismatch.');
+                wp_send_json_error(array(
+                    'message' => 'Security check failed',
+                    'code' => 'nonce_failure',
+                    'details' => 'The security token has expired or is invalid'
+                ));
+                return;
             }
 
             aisheets_debug('Continuing with file processing');
             
-            // Check user permissions - TEMPORARY BYPASS FOR TESTING
-            /* 
+            // Check user permissions
             if (!current_user_can('upload_files')) {
                 aisheets_debug('User permission denied');
                 wp_send_json_error(array(
@@ -629,8 +627,6 @@ class AI_Excel_Editor {
                 ));
                 return;
             }
-            */
-            aisheets_debug('User permission check bypassed for testing');
 
             // Check for file
             if (!isset($_FILES['file']) || empty($_FILES['file']['tmp_name'])) {

--- a/test/manual-security-tests.md
+++ b/test/manual-security-tests.md
@@ -1,0 +1,21 @@
+# Manual Security Tests
+
+These steps verify that unauthorized or forged requests to the `process_excel` AJAX action are rejected.
+
+1. **Logged-out CSRF attempt**
+   - Open a private browser window and visit `admin-ajax.php` directly:
+     ```
+     https://your-site.example/wp-admin/admin-ajax.php?action=process_excel
+     ```
+   - You should receive a JSON error response with a `nonce_failure` code.
+
+2. **Logged-in user without `upload_files` capability**
+   - Log in as a user with minimal permissions (e.g. Subscriber).
+   - Attempt to upload a file using the plugin interface or by crafting a POST request to `admin-ajax.php?action=process_excel`.
+   - The request should fail with an `insufficient_permissions` error.
+
+3. **Invalid nonce value**
+   - While logged in with sufficient permissions, intercept the request made by the plugin and modify the `nonce` parameter to an invalid value.
+   - Resend the request. A `nonce_failure` response should be returned.
+
+Successful completion of the above steps confirms that the security checks are active.


### PR DESCRIPTION
## Summary
- enforce nonce rejection in `handle_excel_processing`
- restore permission checks on uploads
- document manual security tests

## Testing
- `php -l ai-excel-editor.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4bb441a4832a8e1699dfbd4b568c